### PR TITLE
Workaround for importing clusters

### DIFF
--- a/hosted/aks/p0/p0_importing_test.go
+++ b/hosted/aks/p0/p0_importing_test.go
@@ -45,10 +45,7 @@ var _ = Describe("P0Importing", func() {
 			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherClient)
 			Expect(err).To(BeNil())
 			// Workaround to add new Nodegroup till https://github.com/rancher/aks-operator/issues/251 is fixed
-			cluster, err = helper.AddNodePool(cluster, increaseBy, ctx.RancherClient)
-			Expect(err).To(BeNil())
-			err = clusters.WaitClusterToBeUpgraded(ctx.RancherClient, cluster.ID)
-			Expect(err).To(BeNil())
+			cluster.AKSConfig = cluster.AKSStatus.UpstreamSpec
 		})
 		AfterEach(func() {
 			err := helper.DeleteAKSHostCluster(cluster, ctx.RancherClient)

--- a/hosted/eks/p0/p0_importing_test.go
+++ b/hosted/eks/p0/p0_importing_test.go
@@ -38,10 +38,7 @@ var _ = Describe("P0Importing", func() {
 			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherClient)
 			Expect(err).To(BeNil())
 			// Workaround to add new Nodegroup till https://github.com/rancher/aks-operator/issues/251 is fixed
-			cluster, err = helper.AddNodeGroup(cluster, increaseBy, ctx.RancherClient)
-			Expect(err).To(BeNil())
-			err = clusters.WaitClusterToBeUpgraded(ctx.RancherClient, cluster.ID)
-			Expect(err).To(BeNil())
+			cluster.EKSConfig = cluster.EKSStatus.UpstreamSpec
 		})
 		AfterEach(func() {
 			err := helper.DeleteEKSHostCluster(cluster, ctx.RancherClient)

--- a/hosted/gke/p0/p0_importing_test.go
+++ b/hosted/gke/p0/p0_importing_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/rancher/rancher/tests/framework/extensions/workloads/pods"
 	"github.com/rancher/rancher/tests/framework/pkg/config"
 	namegen "github.com/rancher/rancher/tests/framework/pkg/namegenerator"
-
 	"github.com/valaparthvi/highlander-tests/hosted/gke/helper"
 	"github.com/valaparthvi/highlander-tests/hosted/helpers"
 )
@@ -45,10 +44,7 @@ var _ = Describe("P0Importing", func() {
 			cluster, err = helpers.WaitUntilClusterIsReady(cluster, ctx.RancherClient)
 			Expect(err).To(BeNil())
 			// Workaround to add new Nodegroup till https://github.com/rancher/aks-operator/issues/251 is fixed
-			cluster, err = helper.AddNodePool(cluster, increaseBy, ctx.RancherClient)
-			Expect(err).To(BeNil())
-			err = clusters.WaitClusterToBeUpgraded(ctx.RancherClient, cluster.ID)
-			Expect(err).To(BeNil())
+			cluster.GKEConfig = cluster.GKEStatus.UpstreamSpec
 		})
 		AfterEach(func() {
 			err := helper.DeleteGKEHostCluster(cluster, ctx.RancherClient)


### PR DESCRIPTION
Instead of adding a nodepool to populate the Cluster Config, this workaround uses Cluster status to populate the config.